### PR TITLE
sh command report Syntax error: "(" unexpected

### DIFF
--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -29,7 +29,7 @@ impl NixMouseManager {
         // read the environment variable $XDG_SESSION_TYPE
         let output = Command::new("sh")
             .arg("-c")
-            .arg("loginctl show-session $(awk '/tty/ {print $1}' <(loginctl)) -p Type | awk -F= '{print $2}'")
+            .arg("loginctl show-session $(loginctl | awk '/tty/ {print $1}') -p Type | awk -F= '{print $2}'")
             .output()
             .unwrap_or(
                 Command::new("sh")


### PR DESCRIPTION
Signed-off-by: fufesou <shuanglongchen@yeah.net>

Ubuntu 21.10.

The rust command code
```
loginctl show-session $(awk '/tty/ {print $1}' <(loginctl)) -p Type | awk -F= '{print $2}'
```
report sytax error, but the follow code works well
```
loginctl show-session $(loginctl | awk '/tty/ {print $1}') -p Type | awk -F= '{print $2}'
```