### PR TITLE
derive Copy/Clone for MouseEvent

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -2,20 +2,20 @@ use crate::error::Error;
 
 pub type CallbackId = u8;
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum MouseButton {
     Left,
     Middle,
     Right,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum ScrollDirection {
     Up,
     Down,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum MouseEvent {
     RelativeMove(i32, i32),
     AbsoluteMove(i32, i32),


### PR DESCRIPTION
Derive the Copy and Clone traits for the `MouseEvent` struct.

Motivation: I wanted to propagate MouseEvents outside the hook FN, which is made easy using crossbeam. But this needs the data to be Copy.