### PR TITLE
fix: NixMouseManager::new()

### DIFF
--- a/src/nix/mod.rs
+++ b/src/nix/mod.rs
@@ -17,8 +17,6 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 #[cfg(feature = "x11")]
-use std::{process::Command, str::from_utf8};
-#[cfg(feature = "x11")]
 mod x11;
 
 mod uinput;
@@ -34,21 +32,10 @@ impl NixMouseManager {
         {
             // Try to identify the display manager using loginctl, if it fails
             // read the environment variable $XDG_SESSION_TYPE
-            let output = Command::new("sh")
-            .arg("-c")
-            .arg("loginctl show-session $(loginctl | awk '/tty/ {print $1}') -p Type | awk -F= '{print $2}'")
-            .output()
-            .unwrap_or_else(|_|
-                Command::new("sh")
-                    .arg("-c")
-                    .arg("echo $XDG_SESSION_TYPE")
-                    .output().unwrap()
-                );
-
-            let display_manager = from_utf8(&output.stdout).unwrap().trim();
+            let display_manager = std::env::var("XDG_SESSION_TYPE");
 
             match display_manager {
-                "x11" => Box::new(x11::X11MouseManager::new()),
+                Ok(s) if &s == "x11" => Box::new(x11::X11MouseManager::new()),
                 // If the display manager is unknown default to uinput
                 _ => Box::new(uinput::UInputMouseManager::new()),
             }


### PR DESCRIPTION
When the `x11` feature is enabled, this method uses `loginctl` with `awk` to retrieve the detailed session type. In case that `loginctl` does not work, it falls back to executing `bash -c echo $XDG_SESSION_TYPE` to get the session type instead.

However, in my case, `loginctl` returns an empty string instead of an `Err(_)`, which means that even though I am using X11, the method cannot detect my session type. As a result, the method uses `/dev/uinput` instead of x11, which requires root permissions.

I'm wondering if we can directly retrieve the session type via `$XDG_SESSION_TYPE` without having to use `loginctl` initially.