### PR TITLE
Use f64 for cursor position

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -73,8 +73,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match matches.subcommand() {
         Some(("move_to", sub_matches)) => {
-            let x: usize = sub_matches.value_of_t_or_exit("x_position");
-            let y: usize = sub_matches.value_of_t_or_exit("y_position");
+            let x: f64 = sub_matches.value_of_t_or_exit("x_position");
+            let y: f64 = sub_matches.value_of_t_or_exit("y_position");
             mouse_manager.move_to(x, y)?;
         }
         Some(("get_position", _)) => {

--- a/src/common.rs
+++ b/src/common.rs
@@ -19,8 +19,8 @@ pub enum ScrollDirection {
 
 #[derive(Debug, Copy, Clone)]
 pub enum MouseEvent {
-    RelativeMove(i32, i32),
-    AbsoluteMove(i32, i32),
+    RelativeMove(f64, f64),
+    AbsoluteMove(f64, f64),
     Press(MouseButton),
     Release(MouseButton),
     Scroll(ScrollDirection),
@@ -36,9 +36,9 @@ pub trait MouseActions {
     /// use mouce::MouseActions;
     ///
     /// let manager = Mouse::new();
-    /// assert_eq!(manager.move_to(0, 0), Ok(()));
+    /// assert_eq!(manager.move_to(0_f64, 0_f64), Ok(()));
     /// ```
-    fn move_to(&self, x: usize, y: usize) -> Result<(), Error>;
+    fn move_to(&self, x: f64, y: f64) -> Result<(), Error>;
     /// Move the mouse relative to the current position
     ///
     /// # Examples
@@ -48,9 +48,9 @@ pub trait MouseActions {
     /// use mouce::MouseActions;
     ///
     /// let manager = Mouse::new();
-    /// assert_eq!(manager.move_relative(100, 100), Ok(()));
+    /// assert_eq!(manager.move_relative(100_f64, 100_f64), Ok(()));
     /// ```
-    fn move_relative(&self, x_offset: i32, y_offset: i32) -> Result<(), Error>;
+    fn move_relative(&self, x_offset: f64, y_offset: f64) -> Result<(), Error>;
     /// Get the current position of the mouse
     ///
     /// # Examples
@@ -62,12 +62,12 @@ pub trait MouseActions {
     /// use mouce::error::Error;
     ///
     /// let manager = Mouse::new();
-    /// manager.move_to(0, 0);
+    /// manager.move_to(0_f64, 0_f64);
     /// // This function may not be implemented on some platforms such as Linux Wayland
-    /// let valid_outs = vec![Ok((0, 0)), Err(Error::NotImplemented)];
+    /// let valid_outs = vec![Ok((0_f64, 0_f64)), Err(Error::NotImplemented)];
     /// assert!(valid_outs.contains(&manager.get_position()));
     /// ```
-    fn get_position(&self) -> Result<(i32, i32), Error>;
+    fn get_position(&self) -> Result<(f64, f64), Error>;
     /// Press down the given mouse button
     ///
     /// # Examples
@@ -192,7 +192,7 @@ mod tests {
     fn move_to_right_bottom() {
         TEST_EXECUTER.lock().unwrap().run_test(|| {
             let manager = Mouse::new();
-            assert_eq!(manager.move_to(1920, 1080), Ok(()));
+            assert_eq!(manager.move_to(1920_f64, 1080_f64), Ok(()));
         });
     }
 
@@ -201,7 +201,7 @@ mod tests {
     fn move_to_top_left() {
         TEST_EXECUTER.lock().unwrap().run_test(|| {
             let manager = Mouse::new();
-            assert_eq!(manager.move_to(0, 0), Ok(()));
+            assert_eq!(manager.move_to(0_f64, 0_f64), Ok(()));
         });
     }
 
@@ -211,10 +211,10 @@ mod tests {
         TEST_EXECUTER.lock().unwrap().run_test(|| {
             let manager = Mouse::new();
             let sleep_duration = time::Duration::from_millis(1);
-            let mut x = 0;
-            while x < 1920 {
-                assert_eq!(manager.move_to(x, 540), Ok(()));
-                x += 1;
+            let mut x = 0_f64;
+            while x < 1920_f64 {
+                assert_eq!(manager.move_to(x, 540_f64), Ok(()));
+                x += 1_f64;
                 thread::sleep(sleep_duration);
             }
         });
@@ -226,11 +226,11 @@ mod tests {
         TEST_EXECUTER.lock().unwrap().run_test(|| {
             let manager = Mouse::new();
             let sleep_duration = time::Duration::from_millis(1);
-            let mut x = 0;
-            assert_eq!(manager.move_to(0, 540), Ok(()));
-            while x < 1920 {
-                assert_eq!(manager.move_relative(1, 0), Ok(()));
-                x += 1;
+            let mut x = 0_f64;
+            assert_eq!(manager.move_to(0_f64, 540_f64), Ok(()));
+            while x < 1920_f64 {
+                assert_eq!(manager.move_relative(1_f64, 0_f64), Ok(()));
+                x += 1_f64;
                 thread::sleep(sleep_duration);
             }
         });
@@ -242,10 +242,10 @@ mod tests {
         TEST_EXECUTER.lock().unwrap().run_test(|| {
             let manager = Mouse::new();
             let sleep_duration = time::Duration::from_millis(1);
-            let mut y = 0;
-            while y < 1080 {
-                assert_eq!(manager.move_to(960, y), Ok(()));
-                y += 1;
+            let mut y = 0_f64;
+            while y < 1080_f64 {
+                assert_eq!(manager.move_to(960_f64, y), Ok(()));
+                y += 1_f64;
                 thread::sleep(sleep_duration);
             }
         });
@@ -257,11 +257,11 @@ mod tests {
         TEST_EXECUTER.lock().unwrap().run_test(|| {
             let manager = Mouse::new();
             let sleep_duration = time::Duration::from_millis(1);
-            let mut y = 0;
-            assert_eq!(manager.move_to(960, 0), Ok(()));
-            while y < 1080 {
-                assert_eq!(manager.move_relative(0, 1), Ok(()));
-                y += 1;
+            let mut y = 0_f64;
+            assert_eq!(manager.move_to(960_f64, 0_f64), Ok(()));
+            while y < 1080_f64 {
+                assert_eq!(manager.move_relative(0_f64, 1_f64), Ok(()));
+                y += 1_f64;
                 thread::sleep(sleep_duration);
             }
         });
@@ -275,12 +275,12 @@ mod tests {
             match manager.get_position() {
                 Ok(_) => {
                     let positions = vec![
-                        (0, 0),
-                        (100, 100),
-                        (250, 250),
-                        (325, 325),
-                        (400, 100),
-                        (100, 400),
+                        (0_f64, 0_f64),
+                        (100_f64, 100_f64),
+                        (250_f64, 250_f64),
+                        (325_f64, 325_f64),
+                        (400_f64, 100_f64),
+                        (100_f64, 400_f64),
                     ];
 
                     let mut x;
@@ -288,8 +288,8 @@ mod tests {
                     for position in positions.iter() {
                         assert_eq!(manager.move_to(position.0, position.1), Ok(()));
                         (x, y) = manager.get_position().unwrap();
-                        assert_eq!(x, position.0 as i32);
-                        assert_eq!(y, position.1 as i32);
+                        assert_eq!(x, position.0);
+                        assert_eq!(y, position.1);
                     }
                 }
                 Err(error) => assert_eq!(error, Error::NotImplemented),

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -441,7 +441,7 @@ extern "C" {
     fn CFRelease(cf: CFTypeRef);
     fn CFMachPortCreateRunLoopSource(
         allocator: *mut c_void,
-        tap: *const c_void,
+        port: *const c_void,
         order: c_ulong,
     ) -> *mut c_void;
     fn CFRunLoopGetCurrent() -> *mut c_void;

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -101,7 +101,7 @@ impl DarwinMouseManager {
                     CGEventType::OtherMouseUp => Some(MouseEvent::Release(MouseButton::Middle)),
                     CGEventType::MouseMoved => {
                         let point = CGEventGetLocation(cg_event);
-                        Some(MouseEvent::AbsoluteMove(point.x as i32, point.y as i32))
+                        Some(MouseEvent::AbsoluteMove(point.x, point.y))
                     }
                     CGEventType::ScrollWheel => {
                         // CGEventField::scrollWheelEventPointDeltaAxis1 = 96
@@ -189,11 +189,8 @@ impl Drop for DarwinMouseManager {
 }
 
 impl MouseActions for DarwinMouseManager {
-    fn move_to(&self, x: usize, y: usize) -> Result<(), Error> {
-        let cg_point = CGPoint {
-            x: x as f64,
-            y: y as f64,
-        };
+    fn move_to(&self, x: f64, y: f64) -> Result<(), Error> {
+        let cg_point = CGPoint { x, y };
         unsafe {
             let result = CGWarpMouseCursorPosition(cg_point);
             if result != CGError::Success {
@@ -206,12 +203,12 @@ impl MouseActions for DarwinMouseManager {
         Ok(())
     }
 
-    fn move_relative(&self, x_offset: i32, y_offset: i32) -> Result<(), Error> {
+    fn move_relative(&self, x_offset: f64, y_offset: f64) -> Result<(), Error> {
         let (x, y) = self.get_position()?;
-        self.move_to((x + x_offset) as usize, (y + y_offset) as usize)
+        self.move_to(x + x_offset, y + y_offset)
     }
 
-    fn get_position(&self) -> Result<(i32, i32), Error> {
+    fn get_position(&self) -> Result<(f64, f64), Error> {
         unsafe {
             let event = CGEventCreate(null_mut());
             if event == null_mut() {
@@ -219,7 +216,7 @@ impl MouseActions for DarwinMouseManager {
             }
             let cursor = CGEventGetLocation(event);
             CFRelease(event as CFTypeRef);
-            return Ok((cursor.x as i32, cursor.y as i32));
+            return Ok((cursor.x, cursor.y));
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ pub mod darwin;
 #[cfg(target_os = "windows")]
 pub mod windows;
 
-
 /// The `Mouse` struct that implements the `MouseActions`
 ///
 /// # Example usage
@@ -21,16 +20,16 @@ pub mod windows;
 /// ```rust,no_run
 /// use std::thread;
 /// use std::time::Duration;
-/// 
+///
 /// use mouce::{Mouse, MouseActions};
-/// 
+///
 /// fn main() {
 ///     let mouse_manager = Mouse::new();
-/// 
-///     let mut x = 0;
-///     while x < 1920 {
-///         let _ = mouse_manager.move_to(x, 540);
-///         x += 1;
+///
+///     let mut x = 0_f64;
+///     while x < 1920_f64 {
+///         let _ = mouse_manager.move_to(x, 540_f64);
+///         x += 1_f64;
 ///         thread::sleep(Duration::from_millis(2));
 ///     }
 /// }
@@ -105,15 +104,15 @@ impl Default for Mouse {
 }
 
 impl MouseActions for Mouse {
-    fn move_to(&self, x: usize, y: usize) -> Result<(), error::Error> {
+    fn move_to(&self, x: f64, y: f64) -> Result<(), error::Error> {
         self.inner.move_to(x, y)
     }
 
-    fn move_relative(&self, x_offset: i32, y_offset: i32) -> Result<(), error::Error> {
+    fn move_relative(&self, x_offset: f64, y_offset: f64) -> Result<(), error::Error> {
         self.inner.move_relative(x_offset, y_offset)
     }
 
-    fn get_position(&self) -> Result<(i32, i32), error::Error> {
+    fn get_position(&self) -> Result<(f64, f64), error::Error> {
         self.inner.get_position()
     }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -149,9 +149,9 @@ impl Drop for WindowsMouseManager {
 }
 
 impl MouseActions for WindowsMouseManager {
-    fn move_to(&self, x: usize, y: usize) -> Result<(), Error> {
+    fn move_to(&self, x: f64, y: f64) -> Result<(), Error> {
         unsafe {
-            let result = SetCursorPos(x as c_int, y as c_int);
+            let result = SetCursorPos(x.floor() as c_int, y.floor() as c_int);
             if result == 0 {
                 return Err(Error::CustomError(
                     "failed to set the cursor position".to_string(),
@@ -161,16 +161,16 @@ impl MouseActions for WindowsMouseManager {
         Ok(())
     }
 
-    fn move_relative(&self, x_offset: i32, y_offset: i32) -> Result<(), Error> {
+    fn move_relative(&self, x_offset: f64, y_offset: f64) -> Result<(), Error> {
         let (x, y) = self.get_position()?;
-        self.move_to((x + x_offset) as usize, (y + y_offset) as usize)
+        self.move_to(x + x_offset, y + y_offset)
     }
 
-    fn get_position(&self) -> Result<(i32, i32), Error> {
+    fn get_position(&self) -> Result<(f64, f64), Error> {
         match self.get_position_raw() {
             Ok((x, y)) => Ok((
-                x.try_into().expect("Can't fit i64 into i32"),
-                y.try_into().expect("Can't fit i64 into i32"),
+                x.try_into().expect("Cannot fit i32 into f64"),
+                y.try_into().expect("Cannot fit i32 into f64"),
             )),
             Err(e) => Err(e),
         }


### PR DESCRIPTION
Hello 👋

I propose switching to `f64` instead of `usize` or `i32` for representing cursor positions throughout the crate.

Exemplary reasons for that change:
- On Windows, displays extending to the left of the primary display can have negative coordinates. However, functions like [`move_to`](https://github.com/emrebicer/mouce/blob/7e28024d0b11f13ed091ba8fb53216a305db42df/src/windows.rs#L152) take `usize`, making it impossible to move the cursor onto such displays.
- In [`darwin.rs`](https://github.com/emrebicer/mouce/blob/7e28024d0b11f13ed091ba8fb53216a305db42df/src/darwin.rs#L211), negative coordinates may also be incorrectly cast to `usize`.
- On macOS, the system API supports floating-point values, allowing for sub-(logical-)pixel cursor positioning when providing `f64`.

I have started adapting the codebase to use `f64` for cursor positions. However, since I am not actively using or testing on Linux, contributions for Linux-specific changes would be greatly appreciated! This should be a relatively straightforward adaptation.

- [x] Adapt for Windows
- [x] Adapt for macOS
- [ ] Adapt for Linux/X11
- [ ] Adapt for Linux/Wayland