### PR TITLE
Pixel-accurate scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ fn press_button(&self, button: &MouseButton) -> Result<(), Error>;
 fn release_button(&self, button: &MouseButton) -> Result<(), Error>;
 /// Click the given mouse button
 fn click_button(&self, button: &MouseButton) -> Result<(), Error>;
-/// Scroll the mouse wheel towards to the given direction
-fn scroll_wheel(&self, direction: &ScrollDirection) -> Result<(), Error>;
+/// Scroll the mouse wheel towards to the given direction with the given distance
+fn scroll_wheel(&self, direction: &ScrollDirection, distance: u32) -> Result<(), Error>;
 /// Attach a callback function to mouse events
 fn hook(&mut self, callback: Box<dyn Fn(&MouseEvent) + Send>) -> Result<CallbackId, Error>;
 /// Remove the callback function with the given `CallbackId`

--- a/src/common.rs
+++ b/src/common.rs
@@ -23,7 +23,7 @@ pub enum MouseEvent {
     AbsoluteMove(i32, i32),
     Press(MouseButton),
     Release(MouseButton),
-    Scroll(ScrollDirection),
+    Scroll(ScrollDirection, u32),
 }
 
 pub trait MouseActions {
@@ -107,7 +107,7 @@ pub trait MouseActions {
     /// assert_eq!(manager.click_button(&MouseButton::Left), Ok(()));
     /// ```
     fn click_button(&self, button: &MouseButton) -> Result<(), Error>;
-    /// Scroll the mouse wheel towards to the given direction
+    /// Scroll the mouse wheel towards to the given direction with the given distance
     ///
     /// # Examples
     ///
@@ -121,16 +121,16 @@ pub trait MouseActions {
     /// let sleep_duration = time::Duration::from_millis(250);
     ///
     /// for _ in 0..5 {
-    ///     assert_eq!(manager.scroll_wheel(&ScrollDirection::Down), Ok(()));
+    ///     assert_eq!(manager.scroll_wheel(&ScrollDirection::Down, 5), Ok(()));
     ///     thread::sleep(sleep_duration);
     /// }
     ///
     /// for _ in 0..5 {
-    ///     assert_eq!(manager.scroll_wheel(&ScrollDirection::Up), Ok(()));
+    ///     assert_eq!(manager.scroll_wheel(&ScrollDirection::Up, 5), Ok(()));
     ///     thread::sleep(sleep_duration);
     /// }
     /// ```
-    fn scroll_wheel(&self, direction: &ScrollDirection) -> Result<(), Error>;
+    fn scroll_wheel(&self, direction: &ScrollDirection, distance: u32) -> Result<(), Error>;
     /// Attach a callback function to mouse events
     ///
     /// # Examples
@@ -312,7 +312,7 @@ mod tests {
         TEST_EXECUTER.lock().unwrap().run_test(|| {
             let manager = Mouse::new();
             for _ in 0..10 {
-                assert_eq!(manager.scroll_wheel(&ScrollDirection::Down), Ok(()));
+                assert_eq!(manager.scroll_wheel(&ScrollDirection::Down, 5), Ok(()));
                 let sleep_duration = time::Duration::from_millis(250);
                 thread::sleep(sleep_duration);
             }
@@ -325,7 +325,7 @@ mod tests {
         TEST_EXECUTER.lock().unwrap().run_test(|| {
             let manager = Mouse::new();
             for _ in 0..10 {
-                assert_eq!(manager.scroll_wheel(&ScrollDirection::Up), Ok(()));
+                assert_eq!(manager.scroll_wheel(&ScrollDirection::Up, 5), Ok(()));
                 let sleep_duration = time::Duration::from_millis(250);
                 thread::sleep(sleep_duration);
             }
@@ -338,7 +338,7 @@ mod tests {
         TEST_EXECUTER.lock().unwrap().run_test(|| {
             let manager = Mouse::new();
             for _ in 0..10 {
-                assert_eq!(manager.scroll_wheel(&ScrollDirection::Right), Ok(()));
+                assert_eq!(manager.scroll_wheel(&ScrollDirection::Right, 5), Ok(()));
                 let sleep_duration = time::Duration::from_millis(250);
                 thread::sleep(sleep_duration);
             }
@@ -351,7 +351,7 @@ mod tests {
         TEST_EXECUTER.lock().unwrap().run_test(|| {
             let manager = Mouse::new();
             for _ in 0..10 {
-                assert_eq!(manager.scroll_wheel(&ScrollDirection::Left), Ok(()));
+                assert_eq!(manager.scroll_wheel(&ScrollDirection::Left, 5), Ok(()));
                 let sleep_duration = time::Duration::from_millis(250);
                 thread::sleep(sleep_duration);
             }

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -60,14 +60,14 @@ impl DarwinMouseManager {
             let event = match direction {
                 ScrollDirection::Up | ScrollDirection::Down => CGEventCreateScrollWheelEvent(
                     null_mut(),
-                    CGScrollEventUnit::Line,
+                    CGScrollEventUnit::Pixel,
                     2,
                     distance,
                     0,
                 ),
                 ScrollDirection::Right | ScrollDirection::Left => CGEventCreateScrollWheelEvent(
                     null_mut(),
-                    CGScrollEventUnit::Line,
+                    CGScrollEventUnit::Pixel,
                     2,
                     0,
                     distance,
@@ -391,8 +391,8 @@ enum CGEventTapLocation {
 
 #[repr(C)]
 enum CGScrollEventUnit {
-    _Pixel = 0,
-    Line = 1,
+    Pixel = 0,
+    _Line = 1,
 }
 
 #[repr(C)]

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -109,13 +109,25 @@ impl DarwinMouseManager {
                         let delta_y = CGEventGetIntegerValueField(cg_event, 96);
                         let delta_x = CGEventGetIntegerValueField(cg_event, 97);
                         if delta_y > 0 {
-                            Some(MouseEvent::Scroll(ScrollDirection::Up))
+                            Some(MouseEvent::Scroll(
+                                ScrollDirection::Up,
+                                delta_y.abs() as u32,
+                            ))
                         } else if delta_y < 0 {
-                            Some(MouseEvent::Scroll(ScrollDirection::Down))
+                            Some(MouseEvent::Scroll(
+                                ScrollDirection::Down,
+                                delta_y.abs() as u32,
+                            ))
                         } else if delta_x < 0 {
-                            Some(MouseEvent::Scroll(ScrollDirection::Right))
+                            Some(MouseEvent::Scroll(
+                                ScrollDirection::Right,
+                                delta_x.abs() as u32,
+                            ))
                         } else if delta_x > 0 {
-                            Some(MouseEvent::Scroll(ScrollDirection::Left))
+                            Some(MouseEvent::Scroll(
+                                ScrollDirection::Left,
+                                delta_x.abs() as u32,
+                            ))
                         } else {
                             // Probably axis3 wheel scrolled
                             None
@@ -247,10 +259,10 @@ impl MouseActions for DarwinMouseManager {
         self.release_button(button)
     }
 
-    fn scroll_wheel(&self, direction: &ScrollDirection) -> Result<(), Error> {
+    fn scroll_wheel(&self, direction: &ScrollDirection, distance: u32) -> Result<(), Error> {
         let distance = match direction {
-            ScrollDirection::Up | ScrollDirection::Left => 5,
-            ScrollDirection::Down | ScrollDirection::Right => -5,
+            ScrollDirection::Up | ScrollDirection::Left => distance as i32,
+            ScrollDirection::Down | ScrollDirection::Right => -(distance as i32),
         };
         self.create_scroll_wheel_event(distance, direction)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ pub mod darwin;
 #[cfg(target_os = "windows")]
 pub mod windows;
 
-
 /// The `Mouse` struct that implements the `MouseActions`
 ///
 /// # Example usage
@@ -21,12 +20,12 @@ pub mod windows;
 /// ```rust,no_run
 /// use std::thread;
 /// use std::time::Duration;
-/// 
+///
 /// use mouce::{Mouse, MouseActions};
-/// 
+///
 /// fn main() {
 ///     let mouse_manager = Mouse::new();
-/// 
+///
 ///     let mut x = 0;
 ///     while x < 1920 {
 ///         let _ = mouse_manager.move_to(x, 540);
@@ -129,8 +128,12 @@ impl MouseActions for Mouse {
         self.inner.click_button(button)
     }
 
-    fn scroll_wheel(&self, direction: &common::ScrollDirection) -> Result<(), error::Error> {
-        self.inner.scroll_wheel(direction)
+    fn scroll_wheel(
+        &self,
+        direction: &common::ScrollDirection,
+        distance: u32,
+    ) -> Result<(), error::Error> {
+        self.inner.scroll_wheel(direction, distance)
     }
 
     fn hook(

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -78,17 +78,19 @@ impl WindowsMouseManager {
                     WM_MBUTTONUP => Some(MouseEvent::Release(MouseButton::Middle)),
                     WM_RBUTTONUP => Some(MouseEvent::Release(MouseButton::Right)),
                     WM_MOUSEWHEEL => {
+                        // TODO: Extract distance.
                         let delta = get_delta(lpdata) / WHEEL_DELTA as u16;
                         match delta {
-                            1 => Some(MouseEvent::Scroll(ScrollDirection::Up)),
-                            _ => Some(MouseEvent::Scroll(ScrollDirection::Down)),
+                            1 => Some(MouseEvent::Scroll(ScrollDirection::Up, 0)),
+                            _ => Some(MouseEvent::Scroll(ScrollDirection::Down, 0)),
                         }
                     }
                     WM_MOUSEHWHEEL => {
+                        // TODO: Extract distance.
                         let delta = get_delta(lpdata) / WHEEL_DELTA as u16;
                         match delta {
-                            1 => Some(MouseEvent::Scroll(ScrollDirection::Right)),
-                            _ => Some(MouseEvent::Scroll(ScrollDirection::Left)),
+                            1 => Some(MouseEvent::Scroll(ScrollDirection::Right, 0)),
+                            _ => Some(MouseEvent::Scroll(ScrollDirection::Left, 0)),
                         }
                     }
                     _ => None,
@@ -201,12 +203,12 @@ impl MouseActions for WindowsMouseManager {
         self.release_button(button)
     }
 
-    fn scroll_wheel(&self, direction: &ScrollDirection) -> Result<(), Error> {
+    fn scroll_wheel(&self, direction: &ScrollDirection, distance: u32) -> Result<(), Error> {
         let (event, scroll_amount) = match direction {
-            ScrollDirection::Up => (WindowsMouseEvent::Wheel, 150),
-            ScrollDirection::Down => (WindowsMouseEvent::Wheel, -150),
-            ScrollDirection::Right => (WindowsMouseEvent::HWheel, 150),
-            ScrollDirection::Left => (WindowsMouseEvent::HWheel, -150),
+            ScrollDirection::Up => (WindowsMouseEvent::Wheel, distance as i32),
+            ScrollDirection::Down => (WindowsMouseEvent::Wheel, -(distance as i32)),
+            ScrollDirection::Right => (WindowsMouseEvent::HWheel, distance as i32),
+            ScrollDirection::Left => (WindowsMouseEvent::HWheel, -(distance as i32)),
         };
         self.send_input(event, scroll_amount)
     }


### PR DESCRIPTION
Hello 👋,

I need pixel-accurate scrolling, which I find in general more useful than line-accurate scrolling. Thus, I suggest to change the scrolling-related structs and functions to accept a pixel offset to be scrolled instead of scrolling a single line. If there is a serious need for line-accurate scrolling, I suggest to either introduce separate functions for `scroll_lines` and `scroll_pixels` or to add an `enum ScrollUnit { Pixel, Line }` which instance is provided at calling `scroll_wheel`.

I have drafted the changes for macOS and partly for Windows.